### PR TITLE
Select which DBs to backup in MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2021-07-21
+
+### Added
+
+- Select which databases to backup in `[MySQL]` configuration
+
+### Changed
+
+- Now uses blulib for parsing configuration
+
+### Fixed
+
+- Now uses `address` and `port` in `[MySQL]` configuration
+
+## [0.1.0] - 2021-07-04
+
+### Breaking changes
+
+- Moved configuration from `config.py` into ini-like configuration `~/.backup-runner.cfg`
+
+### Changes
+
+- Using tealprint to log messages
+
 ## [0.0.4] - 2021-04-01
 
 ### Fixed

--- a/backuprunner/backup/mysql_backup.py
+++ b/backuprunner/backup/mysql_backup.py
@@ -40,7 +40,6 @@ class MysqlBackup(Backup):
         tar_info = tarfile.TarInfo(name=f"{name}.sql")
         tar_info.size = len(data)
         tar.addfile(tar_info, BytesIO(data))
-        pass
 
     def _get_database(self, name: Optional[str] = None) -> bytes:
         cmd = self._get_sqldump_command(name)

--- a/backuprunner/backup/mysql_backup.py
+++ b/backuprunner/backup/mysql_backup.py
@@ -1,8 +1,10 @@
-import sys
-from subprocess import DEVNULL, run
+import tarfile
+from io import BytesIO
+from subprocess import DEVNULL, PIPE, run
+from typing import List, Optional
 
 from colored import attr, fg
-from tealprint import TealLevel, TealPrint
+from tealprint import TealPrint
 
 from ..config import config
 from .backup import Backup
@@ -21,30 +23,55 @@ class MysqlBackup(Backup):
             )
             return
 
-        out = DEVNULL
-
-        if config.level == TealLevel.debug:
-            out = sys.stdout
-
         TealPrint.info("Backing up MySQL", color=attr("bold"))
+        with tarfile.open(self.filepath, "w:gz") as tar:
+            # Multiple database
+            if len(config.mysql.databases) > 0:
+                for database in config.mysql.databases:
+                    dump = self._get_database(database)
+                    self._add_to_tar_file(tar, database, dump)
+            else:
+                dump = self._get_database()
+                self._add_to_tar_file(tar, "all-databases", dump)
 
+        TealPrint.info("✔ MySQL backup complete!")
+
+    def _add_to_tar_file(self, tar: tarfile.TarFile, name: str, data: bytes) -> None:
+        tar_info = tarfile.TarInfo(name=f"{name}.sql")
+        tar_info.size = len(data)
+        tar.addfile(tar_info, BytesIO(data))
+        pass
+
+    def _get_database(self, name: Optional[str] = None) -> bytes:
+        cmd = self._get_sqldump_command(name)
+        output = run(
+            cmd,
+            stdout=PIPE,
+            stderr=DEVNULL,
+        )
+        return output.stdout
+
+    def _get_sqldump_command(self, db_name: Optional[str]) -> List[str]:
+        """Get the command to dump the sql
+
+        Args:
+            db_name (Optional[str]): dump only the specified database. If 'None' it dumps all databases
+        """
         args = [
             "mysqldump",
             "-u",
             str(config.mysql.username),
             f"--password={config.mysql.password}",
-            "-r",
-            str(self.filepath),
-            "--all-databases",
+            f"--host={config.mysql.address}",
+            f"--port={config.mysql.port}",
         ]
+        if db_name and db_name != "":
+            args.append(db_name)
+        else:
+            args.append(("--all-databases"))
 
-        run(
-            args,
-            stdout=out,
-        )
-
-        TealPrint.info("✔ MySQL backup complete!")
+        return args
 
     @property
     def extension(self) -> str:
-        return "sql"
+        return "tgz"

--- a/backuprunner/utils/config_file_args.py
+++ b/backuprunner/utils/config_file_args.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 
 class ConfigFileArgs:

--- a/backuprunner/utils/config_file_args.py
+++ b/backuprunner/utils/config_file_args.py
@@ -27,14 +27,15 @@ class Backups:
 
 class Mysql:
     def __init__(self) -> None:
-        self.username: Optional[str] = None
-        self.password: Optional[str] = None
+        self.username: str = ""
+        self.password: str = ""
         self.address: str = "localhost"
         self.port: int = 3306
+        self.databases: List[str] = []
 
 
 class Email:
     def __init__(self) -> None:
-        self.to_address: Optional[str] = None
-        self.from_address: Optional[str] = None
+        self.to_address: str = ""
+        self.from_address: str = ""
         self.disk_percentage: int = 85

--- a/backuprunner/utils/config_file_parser.py
+++ b/backuprunner/utils/config_file_parser.py
@@ -1,10 +1,8 @@
-import configparser
 from enum import Enum
 from pathlib import Path
-from shutil import copy
-from site import getuserbase
-from typing import Any, Callable, Tuple
 
+from blulib.config_parser import ConfigParser
+from blulib.config_parser.config_parser import SectionNotFoundError
 from colored import attr
 from tealprint import TealPrint
 
@@ -27,84 +25,61 @@ class ConfigFileParser:
         args = ConfigFileArgs()
 
         if not self.path.exists():
-            TealPrint.error(f"Could not find config file {self.path}. Please add!", exit=True)
+            TealPrint.warning(f"Could not find config file {self.path}. Please add!", exit=True)
             return args
 
-        config = configparser.ConfigParser()
+        config = ConfigParser()
         config.read(self.path)
 
         TealPrint.verbose(f"Reading configuration {self.path}", color=attr("bold"))
 
-        if Sections.general.value in config:
-            TealPrint.debug(f"[{Sections.general.value}]", indent=1)
-            general = config[Sections.general.value]
-            ConfigFileParser._set_str(
+        try:
+            config.to_object(
                 args.general,
-                general,
+                "General",
                 "backup_location",
+                "int:days_to_keep",
             )
-            ConfigFileParser._set_int(
-                args.general,
-                general,
-                "days_to_keep",
-            )
-        else:
-            ConfigFileParser._print_section_not_found(Sections.general.value)
+        except SectionNotFoundError:
+            ConfigFileParser._print_section_not_found("General")
 
-        if Sections.backups.value in config:
-            TealPrint.debug(f"[{Sections.backups.value}]")
-            backups = config[Sections.backups.value]
-            ConfigFileParser._set_str_list(
+        try:
+            config.to_object(
                 args.backups,
-                backups,
-                "daily",
-                "weekly",
-                "monthly",
-            )
-            ConfigFileParser._set_str(
-                args.backups,
-                backups,
+                "Backups",
                 "daily_alias",
                 "weekly_alias",
                 "monthly_alias",
+                "str_list:daily",
+                "str_list:weekly",
+                "str_list:monthly",
             )
-        else:
-            ConfigFileParser._print_section_not_found(Sections.backups.value)
+        except SectionNotFoundError:
+            ConfigFileParser._print_section_not_found("Backups")
 
-        if Sections.mysql.value in config:
-            TealPrint.debug(f"[{Sections.mysql.value}]")
-            mysql = config[Sections.mysql.value]
-            ConfigFileParser._set_str(
+        try:
+            config.to_object(
                 args.mysql,
-                mysql,
+                "MySQL",
                 "username",
                 "password",
                 "address",
+                "int:port",
+                "str_list:databases",
             )
-            ConfigFileParser._set_int(
-                args.mysql,
-                mysql,
-                "port",
-            )
-        else:
-            ConfigFileParser._print_section_not_found(Sections.mysql.value)
+        except SectionNotFoundError:
+            ConfigFileParser._print_section_not_found("MySQL")
 
-        if Sections.email.value in config:
-            TealPrint.debug(f"[{Sections.email.value}]")
-            email = config[Sections.email.value]
-            ConfigFileParser._set_str(
+        try:
+            config.to_object(
                 args.email,
-                email,
+                "Email",
                 "to->to_address",
                 "from->from_address",
+                "int:disk_percentage",
             )
-            ConfigFileParser._set_int(
-                args.email,
-                email,
-                "disk_percentage",
-            )
-        else:
-            ConfigFileParser._print_section_not_found(Sections.email.value)
+        except SectionNotFoundError:
+            ConfigFileParser._print_section_not_found("Email")
 
         self._check_required(args)
 
@@ -114,58 +89,12 @@ class ConfigFileParser:
     def _print_section_not_found(section: str) -> None:
         TealPrint.warning(f"⚠ [{section}] section not found!", indent=1)
 
-    @staticmethod
-    def _set_str(args: Any, section: configparser.SectionProxy, *varnames: str) -> None:
-        ConfigFileParser._set(args, section.get, *varnames)
-
-    @staticmethod
-    def _set_str_list(args: Any, section: configparser.SectionProxy, *varnames: str) -> None:
-        for varname in varnames:
-            conf_varname, arg_varname = ConfigFileParser._get_config_and_arg_names(varname)
-            values = getattr(args, arg_varname)
-            value = section.get(conf_varname, fallback="")
-            if value != "":
-                values = value.split("\n")
-            setattr(args, arg_varname, values)
-
-    @staticmethod
-    def _set_int(args: Any, section: configparser.SectionProxy, *varnames: str) -> None:
-        ConfigFileParser._set(args, section.getint, *varnames)
-
-    @staticmethod
-    def _set(args: Any, get_func: Callable, *varnames: str) -> None:
-        for varname in varnames:
-            conf_varname, arg_varname = ConfigFileParser._get_config_and_arg_names(varname)
-            default = getattr(args, arg_varname)
-            value = get_func(conf_varname, fallback=default)
-            setattr(args, arg_varname, value)
-
-    @staticmethod
-    def _get_config_and_arg_names(varname: str) -> Tuple[str, str]:
-        split = varname.split("->")
-        if len(split) == 2:
-            return (split[0], split[1])
-        return (split[0], split[0])
-
     def _check_required(self, args: ConfigFileArgs) -> None:
         if len(args.general.backup_location) == 0:
             self._print_missing("General", "backup_location")
 
     def _print_missing(self, section: str, varname: str) -> None:
-        TealPrint.error(
+        TealPrint.warning(
             f"Missing {varname} under section {section}. " + f"Please add it to your configuration file {self.path}",
             exit=True,
         )
-
-    def create_if_not_exists(self) -> None:
-        if self.path.exists():
-            return
-
-        # Copy file from config location to home
-        example_name = f"{config.app_name}-example.cfg"
-        example_path = Path(getuserbase()).joinpath("config", example_name)
-
-        if not example_path.exists():
-            return
-
-        copy(example_path, self.path)

--- a/config/backup-runner-example.cfg
+++ b/config/backup-runner-example.cfg
@@ -62,6 +62,11 @@ backup_location = /mnt/backup
 # address = localhost
 # port = 3306
 
+# (Optional)
+# Databases to take a backup off. If not specified, it will take a backup of all databases
+# databases =
+    # wordpress
+    # another_db
 
 [Email]
 # Send out email warnings about a full disk, or when a backup failed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tealprint==0.1.0
+blulib==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,11 @@ setup(
     entry_points={"console_scripts": [f"{project_slug}={module_name}.__main__:main"]},
     include_package_data=True,
     data_files=[(f"config", [f"config/{project_slug}-example.cfg"])],
-    install_requires=["psutil", "tealprint"],
+    install_requires=[
+        "psutil",
+        "tealprint",
+        "blulib",
+    ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
🐛 Now uses MySQL address and port

Short sentence what this PR is about.

### What changed?
- Can now select which DBs to backup from MySQL in the `.backup-runner.cfg`
- Now uses MySQL address and port

### Testing

- [ ] Added unit tests
- [X] Manual tested to backup specific DBs

### Safety checklist

- [x] I have reviewed my own code
